### PR TITLE
Allow backward navigation to parent directories

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,11 +67,27 @@
 
     const fileList = document.getElementById("fileList");
 
+    const itemUrlStack = [];
+
     function fetchContents(url) {
       fetch(url)
         .then((response) => response.json())
         .then((data) => {
           fileList.innerHTML = "";
+
+          if (itemUrlStack.length) {
+            const listItem = document.createElement("li");
+            const link = document.createElement("a");
+
+            link.textContent = "../";
+            link.onclick = () => {
+              const parentUrl = itemUrlStack.pop();
+              fetchContents(parentUrl);
+            }
+
+            listItem.appendChild(link);
+            fileList.appendChild(listItem);
+          }
 
           data.forEach((item) => {
             const listItem = document.createElement("li");
@@ -80,7 +96,10 @@
             if (item.type === "dir") {
               // If it's a directory, create a link to fetch its contents
               link.textContent = `${item.name}`;
-              link.onclick = () => fetchContents(item.url);
+              link.onclick = () => {
+                itemUrlStack.push(url);
+                fetchContents(item.url);
+              }
             } else if (item.name.endsWith(".link")) {
               // If it's a .link file, the name of the file is the title of the link, the contents are used to build the link, appended to the cloudFrontUrl
               fetch(item.download_url)


### PR DESCRIPTION
Modifies the Index page to manage a stack of parent URLs when calling the `fetchContents()` function. If there is a URL on the stack, then it is rendered as a top level link with the text `'../'` and a click handler that will pop the stack before calling `fetchContents()`.

Conversely, when a directory link is clicked, the click handler will now push the current URL onto the stack before calling `fetchContents()`.