### PR TITLE
[PM-9235] Remove content-length request for `.link` files

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,28 +114,6 @@
                   link.textContent = item.name.replace(".link", ".zip");
                   link.target = "_blank";
                   link.rel = "noopener noreferrer";
-
-                  // Send a HTTP HEAD request to link.href and read the Content-Length header to get the file size
-                  fetch(link.href, {method: "HEAD", mode: "no-cors"})
-                    .then((response) => {
-                      const contentLength =
-                        response.headers.get("Content-Length");
-                      const fileSize = document.createElement("span");
-                      if (contentLength > 1024 * 1024) {
-                        fileSize.textContent = ` (${(
-                          contentLength /
-                          (1024 * 1024)
-                        ).toFixed(2)} MB)`;
-                      } else {
-                        fileSize.textContent = ` (${(
-                          contentLength / 1024
-                        ).toFixed(2)} KB)`;
-                      }
-                      link.appendChild(fileSize);
-                    })
-                    .catch((error) =>
-                      console.error("Error fetching link contents:", error)
-                    );
                 })
                 .catch((error) =>
                   console.error("Error fetching link contents:", error)


### PR DESCRIPTION
[PM-9235](https://input-output.atlassian.net/browse/PM-9235)

Since the servers hosting the files identified by `.link` entries do not support `Access-Control-Allow-Headers` for the content length header on the originating OPTIONS request, this PR removes the request to try and obtain it.